### PR TITLE
Make lint in CI and cleanup Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,12 @@ env:
   - GO111MODULE=on
 
 install:
-  - make install
+  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.22.2
 
 script:
   - make test
+  - golangci-lint run
 
 after_success:
-  - make report-coveralls
+  - go get github.com/mattn/goveralls
+  - goveralls -coverprofile=coverage.out -service=travis-ci

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test help fmt check-fmt install report-coveralls benchmark
+.PHONY: test help fmt report-coveralls benchmark lint
 
 help: ## Show the help text
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "    \033[36m%-20s\033[93m %s\n", $$1, $$2}'
@@ -9,6 +9,9 @@ test: ## Run unit tests
 	@echo "Testing without timex_disable tag (normal)"
 	@go test -coverprofile=coverage.out -covermode=atomic -race ./...
 
+lint:
+	@golangci-lint run
+
 fmt: ## Format files
 	@goimports -w $$(find . -name "*.go" -not -path "./vendor/*")
 
@@ -17,6 +20,3 @@ benchmark: ## Run benchmarks
 	@go test -run=NONE -benchmem -benchtime=5s -bench=. -tags=timex_disable .
 	@echo "Benchmarks without timex_disable tag (normal)"
 	@go test -run=NONE -benchmem -benchtime=5s -bench=. .	
-
-report-coveralls: ## Reports generated coverage profile to coveralls.io. Intended to be used only from travis
-	go get github.com/mattn/goveralls && goveralls -coverprofile=coverage.out -service=travis-ci

--- a/funcs.go
+++ b/funcs.go
@@ -51,8 +51,9 @@ func Override(implementation Implementation) func() {
 }
 
 // impl stores the current implementation being used
-// we don't use the RWMutex to read the impl itself because atomic.Value is faster in a _frequent read - unfrequent write_
-// scenario according to the docs https://tip.golang.org/pkg/sync/atomic/#Value
+// we don't use the RWMutex to read the impl itself because atomic.Value is faster
+// in a _frequent read - unfrequent write_ scenario according to the docs
+// https://tip.golang.org/pkg/sync/atomic/#Value
 var impl atomic.Value
 
 type implValue struct{ Implementation }


### PR DESCRIPTION
Makefile now contains only user-runnable commands, the ones running only
in CI, like goveralls, are left in .travis-ci.yml