### PR TITLE
Rename defaultImpl to Default

### DIFF
--- a/default.go
+++ b/default.go
@@ -2,45 +2,45 @@ package timex
 
 import "time"
 
-// defaultImpl uses time package functions
-type defaultImpl struct{}
+// Default uses time package functions
+type Default struct{}
 
 // Now can be used as a replacement of time.Now()
-func (defaultImpl) Now() time.Time {
+func (Default) Now() time.Time {
 	return time.Now()
 }
 
 // Since can be used as a replacement of time.Since()
-func (defaultImpl) Since(t time.Time) time.Duration {
+func (Default) Since(t time.Time) time.Duration {
 	return time.Since(t)
 }
 
 // Until can be used as a replacement of time.Until()
-func (defaultImpl) Until(t time.Time) time.Duration {
+func (Default) Until(t time.Time) time.Duration {
 	return time.Until(t)
 }
 
 // AfterFunc can be used as a replacement of time.AfterFunc()
-func (defaultImpl) AfterFunc(d time.Duration, f func()) Timer {
+func (Default) AfterFunc(d time.Duration, f func()) Timer {
 	return timer{time.AfterFunc(d, f)}
 }
 
 // Sleep can be used as a replacement of time.Sleep()
-func (defaultImpl) Sleep(d time.Duration) {
+func (Default) Sleep(d time.Duration) {
 	time.Sleep(d)
 }
 
 // After can be used a replacement of time.After()
-func (defaultImpl) After(d time.Duration) <-chan time.Time {
+func (Default) After(d time.Duration) <-chan time.Time {
 	return time.After(d)
 }
 
 // NewTicker creates a new ticker as replacement of time.NewTicker()
-func (defaultImpl) NewTicker(d time.Duration) Ticker {
+func (Default) NewTicker(d time.Duration) Ticker {
 	return ticker{time.NewTicker(d)}
 }
 
 // NewTimer creates a new timer as replacement of time.NewTimer()
-func (defaultImpl) NewTimer(d time.Duration) Timer {
+func (Default) NewTimer(d time.Duration) Timer {
 	return timer{time.NewTimer(d)}
 }

--- a/default_test.go
+++ b/default_test.go
@@ -8,19 +8,19 @@ import (
 )
 
 func TestDefault_Now(t *testing.T) {
-	diff := time.Since(defaultImpl{}.Now())
+	diff := time.Since(Default{}.Now())
 	assert.True(t, diff < time.Second)
 	assert.True(t, diff > 0)
 }
 
 func TestDefault_Since(t *testing.T) {
-	diff := defaultImpl{}.Since(time.Now())
+	diff := Default{}.Since(time.Now())
 	assert.True(t, diff < time.Second)
 	assert.True(t, diff > 0)
 }
 
 func TestDefault_Until(t *testing.T) {
-	diff := defaultImpl{}.Until(time.Now())
+	diff := Default{}.Until(time.Now())
 	assert.True(t, diff < 0)
 	assert.True(t, diff > -time.Second)
 }
@@ -29,7 +29,7 @@ func TestDefault_AfterFunc(t *testing.T) {
 	timeout := time.After(time.Second)
 	ok := make(chan struct{})
 
-	defaultImpl{}.AfterFunc(time.Millisecond, func() { close(ok) })
+	Default{}.AfterFunc(time.Millisecond, func() { close(ok) })
 
 	select {
 	case <-ok:
@@ -44,7 +44,7 @@ func TestDefault_Sleep(t *testing.T) {
 	ok := make(chan struct{})
 
 	go func() {
-		defaultImpl{}.Sleep(time.Millisecond)
+		Default{}.Sleep(time.Millisecond)
 		close(ok)
 	}()
 
@@ -58,7 +58,7 @@ func TestDefault_Sleep(t *testing.T) {
 
 func TestDefault_After(t *testing.T) {
 	timeout := time.After(time.Second)
-	ok := defaultImpl{}.After(time.Millisecond)
+	ok := Default{}.After(time.Millisecond)
 
 	select {
 	case <-ok:
@@ -70,7 +70,7 @@ func TestDefault_After(t *testing.T) {
 
 func TestDefault_NewTicker(t *testing.T) {
 	timeout := time.After(time.Second)
-	ticker := defaultImpl{}.NewTicker(100 * time.Millisecond)
+	ticker := Default{}.NewTicker(100 * time.Millisecond)
 
 	select {
 	case <-ticker.C():
@@ -81,7 +81,7 @@ func TestDefault_NewTicker(t *testing.T) {
 
 	ticker.Stop()
 
-	ok := defaultImpl{}.After(200 * time.Millisecond)
+	ok := Default{}.After(200 * time.Millisecond)
 
 	select {
 	case <-ticker.C():
@@ -94,7 +94,7 @@ func TestDefault_NewTicker(t *testing.T) {
 func TestDefault_NewTimer(t *testing.T) {
 	t.Run("tick", func(t *testing.T) {
 		timeout := time.After(time.Second)
-		timer := defaultImpl{}.NewTimer(100 * time.Millisecond)
+		timer := Default{}.NewTimer(100 * time.Millisecond)
 
 		select {
 		case <-timer.C():
@@ -105,7 +105,7 @@ func TestDefault_NewTimer(t *testing.T) {
 	})
 
 	t.Run("stop", func(t *testing.T) {
-		timer := defaultImpl{}.NewTimer(100 * time.Millisecond)
+		timer := Default{}.NewTimer(100 * time.Millisecond)
 		timer.Stop()
 
 		ok := After(200 * time.Millisecond)

--- a/funcs.go
+++ b/funcs.go
@@ -45,7 +45,7 @@ func Override(implementation Implementation) func() {
 	overridden.Lock()
 	impl.Store(implValue{implementation})
 	return func() {
-		impl.Store(implValue{defaultImpl{}})
+		impl.Store(implValue{Default{}})
 		overridden.Unlock()
 	}
 }
@@ -59,5 +59,5 @@ var impl atomic.Value
 type implValue struct{ Implementation }
 
 func init() {
-	impl.Store(implValue{defaultImpl{}})
+	impl.Store(implValue{Default{}})
 }

--- a/implementation.go
+++ b/implementation.go
@@ -20,4 +20,4 @@ type Implementation interface {
 }
 
 //go:generate mockery -case underscore -outpkg timexmock -output timexmock -name Implementation
-var _ Implementation = defaultImpl{}
+var _ Implementation = Default{}


### PR DESCRIPTION
According to the documentation, it should be possible to create a default `timex` instance to inject it with DI.
But actually there is no `timex.Default{}`, but only unexported `timex.defaultImpl{}`.
This PR renames `defaultImpl` to `Default` in order to make it work like it's described in the README