### PR TITLE
Draft v1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2020-08-03
+### Added
+- Default implementation is now exposed as `timex.Default` [#2](https://github.com/cabify/timex/pull/2)
+
 ## [1.0.0] - 2020-01-07
 ### Added
 - Initial commit with all the previous implementation squashed into one commit.
 
 
-[Unreleased]: https://github.com/cabify/timex/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/cabify/timex/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/cabify/timex/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/cabify/timex/compare/v1.0.0
 


### PR DESCRIPTION
Exposes default implementation as `timex.Default`.

Ref: https://github.com/cabify/timex/pull/2